### PR TITLE
Update Exercise5.md

### DIFF
--- a/Exercises/Exercise5.md
+++ b/Exercises/Exercise5.md
@@ -14,7 +14,9 @@ The controller is automatically wired up to be accessible at
 	/umbraco/Backoffice/Ingredient/IngredientApi/
 
 ##IngredientTreeController.cs
-Class for the ingredient tree, it is annotated with tree meta data, like which section to be used in, label and alias. 
+Class for the ingredient tree, it is annotated with tree meta data, that specifies the section (location of the tree), alias and label. 
+
+	[Tree("settings", "ingredientTree", "Ingredient")]
 
 It contains methods for providing tree items for the tree, and menu items for each item in the tree. By default the tree contains no information about which views to use with the tree items, since these are setup by convention to point at __/app_plugins/ingredient/backoffice/ingredientTree/__
 


### PR DESCRIPTION
I got a little lost jumping from Excercise 5 to 6 because I didn't see an entire new section (which is how I'm used to thinking of trees). It took me several minutes and some clicking around to find it and only then did I realize that the code told me where it was. 

My goal here is just to highlight that part of the code and explicitly introduce users to the location of the ingredient tree before the next exercise when you're instructed to click on it. It doesn't have to use this language of course.
